### PR TITLE
feat: 系统Prompt模块抽离-会话状态判断

### DIFF
--- a/src/conversation-store.ts
+++ b/src/conversation-store.ts
@@ -1,0 +1,174 @@
+/**
+ * 对话历史追踪存储
+ * 用于判断是否是与某个用户/群组的首次对话
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+
+// 对话状态接口
+export interface ConversationState {
+    /** 对话 ID (userId 或 groupId) */
+    conversationId: string;
+    /** 是否是新对话 */
+    isNewConversation: boolean;
+    /** 首次对话的时间戳 */
+    firstMessageAt: number;
+    /** 最后活动时间 */
+    lastMessageAt: number;
+    /** 保存时间 */
+    savedAt: number;
+}
+
+// 对话数据目录
+const CONVERSATION_DIR = path.join(
+    process.env.HOME || "/tmp",
+    "clawd",
+    "qqbot-data"
+);
+console.log(`[qqbot-CONVERSATION_DIR] = ${CONVERSATION_DIR}`);
+
+// 对话过期时间（15天）- 超过这个时间认为是新会话
+const CONVERSATION_EXPIRE_TIME = 15 * 24 * 60 * 60 * 1000;
+
+// 内存缓存
+const conversationCache = new Map<string, ConversationState>();
+
+/**
+ * 确保目录存在
+ */
+function ensureDir(): void {
+    if (!fs.existsSync(CONVERSATION_DIR)) {
+        fs.mkdirSync(CONVERSATION_DIR, { recursive: true });
+    }
+}
+
+/**
+ * 获取对话数据文件路径
+ */
+function getConversationPath(conversationId: string): string {
+    // 清理 ID 中的特殊字符
+    const safeId = conversationId.replace(/[^a-zA-Z0-9_:\-\.]/g, "_");
+    return path.join(CONVERSATION_DIR, `conversation-${safeId}.json`);
+}
+
+/**
+ * 检查对话是否是新的
+ * @param conversationId 对话 ID (userId 或 group:groupId)
+ * @returns true 表示是新对话，false 表示是继续对话
+ */
+export function checkConversationStatus(conversationId: string): boolean {
+    // 检查内存缓存
+    if (conversationCache.has(conversationId)) {
+        const cached = conversationCache.get(conversationId)!;
+        const now = Date.now();
+
+        // 如果距离上次消息超过过期时间，认为是新会话
+        if (now - cached.lastMessageAt > CONVERSATION_EXPIRE_TIME) {
+            cached.isNewConversation = true;
+            cached.firstMessageAt = now;
+            cached.lastMessageAt = now;
+            cached.savedAt = now;
+            saveConversationState(conversationId, cached);
+            return true;
+        }
+
+        // 获取当前对话的新旧状态
+        const isNew = cached.isNewConversation;
+
+        // 更新最后活动时间，并将标志改为 false（表示已处理过）
+        cached.lastMessageAt = now;
+        cached.isNewConversation = false;
+        cached.savedAt = now;
+        saveConversationState(conversationId, cached);
+
+        return isNew;
+    }
+
+    // 检查文件存储
+    const filePath = getConversationPath(conversationId);
+    const now = Date.now();
+
+    try {
+        if (fs.existsSync(filePath)) {
+            const data = fs.readFileSync(filePath, "utf-8");
+            const state = JSON.parse(data) as ConversationState;
+
+            // 检查是否过期
+            if (now - state.lastMessageAt > CONVERSATION_EXPIRE_TIME) {
+                // 对话过期，认为是新会话
+                const newState: ConversationState = {
+                    conversationId,
+                    isNewConversation: true,
+                    firstMessageAt: now,
+                    lastMessageAt: now,
+                    savedAt: now,
+                };
+                conversationCache.set(conversationId, newState);
+                saveConversationState(conversationId, newState);
+                return true;
+            }
+
+            // 获取当前的新旧状态
+            const isNew = state.isNewConversation;
+
+            // 更新最后活动时间，并将标志改为 false（表示已处理过）
+            state.lastMessageAt = now;
+            state.isNewConversation = false;
+            state.savedAt = now;
+            conversationCache.set(conversationId, state);
+            saveConversationState(conversationId, state);
+
+            return isNew;
+        }
+    } catch (err) {
+        console.log(`[conversation-store] Error reading conversation for ${conversationId}: ${err}`);
+    }
+
+    // 文件不存在，这是新对话
+    const newState: ConversationState = {
+        conversationId,
+        isNewConversation: true,
+        firstMessageAt: now,
+        lastMessageAt: now,
+        savedAt: now,
+    };
+    conversationCache.set(conversationId, newState);
+    saveConversationState(conversationId, newState);
+    return true;
+}
+
+/**
+ * 保存对话状态到文件
+ */
+function saveConversationState(conversationId: string, state: ConversationState): void {
+    ensureDir();
+    const filePath = getConversationPath(conversationId);
+
+    try {
+        fs.writeFileSync(filePath, JSON.stringify(state, null, 2), "utf-8");
+    } catch (err) {
+        console.error(`[conversation-store] Error saving conversation state for ${conversationId}: ${err}`);
+    }
+}
+
+/**
+ * 清除所有对话历史（用于测试或重置）
+ */
+export function clearAllConversations(): void {
+    conversationCache.clear();
+
+    try {
+        if (fs.existsSync(CONVERSATION_DIR)) {
+            const files = fs.readdirSync(CONVERSATION_DIR);
+            for (const file of files) {
+                if (file.startsWith("conversation-")) {
+                    fs.unlinkSync(path.join(CONVERSATION_DIR, file));
+                }
+            }
+        }
+    } catch (err) {
+        console.error(`[conversation-store] Error clearing conversations: ${err}`);
+    }
+}
+

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -4,6 +4,7 @@ import * as fs from "node:fs";
 import type { ResolvedQQBotAccount, WSPayload, C2CMessageEvent, GuildMessageEvent, GroupMessageEvent } from "./types.js";
 import { getAccessToken, getGatewayUrl, sendC2CMessage, sendChannelMessage, sendGroupMessage, clearTokenCache, sendC2CImageMessage, sendGroupImageMessage, initApiConfig, startBackgroundTokenRefresh, stopBackgroundTokenRefresh, sendC2CInputNotify } from "./api.js";
 import { loadSession, saveSession, clearSession, type SessionState } from "./session-store.js";
+import { generateBuiltinPrompt } from "./system-prompt.js";
 import { recordKnownUser, flushKnownUsers } from "./known-users.js";
 import { getQQBotRuntime } from "./runtime.js";
 import { startImageServer, isImageServerRunning, downloadFile, type ImageServerConfig } from "./image-server.js";
@@ -437,70 +438,14 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
         const envelopeOptions = pluginRuntime.channel.reply.resolveEnvelopeFormatOptions(cfg);
 
         // 组装消息体，添加系统提示词
-        let builtinPrompt = "";
-        
-        // ============ 用户标识信息（用于定时提醒和主动消息） ============
-        const isGroupChat = event.type === "group";
-        const targetAddress = isGroupChat ? `group:${event.groupOpenid}` : event.senderId;
-        
-        builtinPrompt += `
-【当前用户信息】
-- 用户 openid: ${event.senderId}
-- 用户昵称: ${event.senderName || "未知"}
-- 消息类型: ${isGroupChat ? "群聊" : "私聊"}
-- 当前消息 message_id: ${event.messageId}${isGroupChat ? `
-- 群组 group_openid: ${event.groupOpenid}` : ""}
-
-【定时提醒能力】
-你可以帮助用户设置定时提醒。使用exec工具来来运行bash命令 openclaw cron 命令而不是直接使用 "cron" 工具：
-
-示例：5分钟后提醒用户喝水
-\`\`\`bash
-openclaw cron add \\
-  --name "提醒喝水-${event.senderName || "用户"}" \\
-  --at "5m" \\
-  --session isolated \\
-  --message "💧 该喝水啦！" \\
-  --deliver \\
-  --channel qqbot \\
-  --to "${targetAddress}" \\
-  --delete-after-run
-\`\`\`
-
-关键参数说明：
-- \`--to\`: 目标地址（当前用户: ${targetAddress}）
-- \`--at\`: 一次性定时任务的触发时间
-  - 相对时间格式：数字+单位，如 \`5m\`（5分钟）、\`1h\`（1小时）、\`2d\`（2天）【注意：不要加 + 号】
-  - 绝对时间格式：ISO 8601 带时区，如 \`2026-02-01T14:00:00+08:00\`
-- \`--cron\`: 周期性任务（如 \`0 8 * * *\` 每天早上8点）
-- \`--tz "Asia/Shanghai"\`: 周期任务务必设置时区
-- \`--delete-after-run\`: 一次性任务必须添加此参数
-- \`--message\`: 消息内容（必填，不能为空！这是定时提醒触发时直接发送给用户的内容）
-- \`--session isolated\` 独立会话任务
-
-⚠️ 重要注意事项：
-1. --at 参数格式：相对时间用 \`5m\`、\`1h\` 等（不要加 + 号！）；绝对时间用完整 ISO 格式
-2. --message 参数必须有实际内容，不能为空字符串
-3. cron add 命令不支持 --reply-to 参数，定时提醒只能作为主动消息发送`;
-
-        // 🎯 发送图片功能：使用 <qqimg> 标签发送本地或网络图片
-        // 系统会自动将本地文件转换为 Base64 发送，不需要图床服务器
-        builtinPrompt += `
-
-【发送图片】
-你可以直接发送图片给用户！使用 <qqimg> 标签包裹图片路径：
-
-<qqimg>图片路径</qqimg>
-
-示例：
-- <qqimg>/Users/xxx/images/photo.jpg</qqimg>  （本地文件）
-- <qqimg>https://example.com/image.png</qqimg>  （网络图片）
-
-⚠️ 注意：
-- 必须使用 <qqimg>路径</qqimg> 格式
-- 本地路径必须是绝对路径，支持 png、jpg、jpeg、gif、webp 格式
-- 图片文件/URL 必须有效，否则发送失败
-- Markdown格式下，也必须使用该方式发送图片`;
+        const builtinPrompt = generateBuiltinPrompt({
+          eventType: event.type,
+          senderId: event.senderId,
+          senderName: event.senderName,
+          messageId: event.messageId,
+          timestamp: event.timestamp,
+          groupOpenid: event.groupOpenid,
+        });
         
         const systemPrompts = [builtinPrompt];
         if (account.systemPrompt) {

--- a/src/system-prompt.ts
+++ b/src/system-prompt.ts
@@ -1,0 +1,139 @@
+/**
+ * 系统提示词生成模块
+ * 根据会话状态生成相应的系统提示词
+ * 支持首次详细和后续精简两种模式
+ */
+
+import { checkConversationStatus } from "./conversation-store.js";
+
+export interface SystemPromptOptions {
+    /** 事件类型 */
+    eventType: "c2c" | "guild" | "dm" | "group";
+    /** 发送者 ID */
+    senderId: string;
+    /** 发送者昵称 */
+    senderName?: string;
+    /** 消息 ID */
+    messageId: string;
+    /** 消息时间戳 */
+    timestamp: string;
+    /** 群组 openid（仅当 eventType 为 group 时） */
+    groupOpenid?: string;
+}
+
+/**
+ * 生成系统内置提示词
+ * @param options 选项对象
+ * @returns 生成的系统提示词
+ */
+export function generateBuiltinPrompt(options: SystemPromptOptions): string {
+    const {
+        eventType,
+        senderId,
+        senderName,
+        messageId,
+        timestamp,
+        groupOpenid,
+    } = options;
+
+    // 判断是否是群聊
+    const isGroupChat = eventType === "group";
+
+    // 构建目标地址（用于定时提醒）
+    const targetAddress = isGroupChat ? `group:${groupOpenid}` : senderId;
+
+    // 构建会话 ID（用于判断是否是新会话）
+    const conversationId = isGroupChat ? `group:${groupOpenid}` : senderId;
+
+    // 检查是否是新会话
+    const isNewConversation = checkConversationStatus(conversationId);
+
+    // 格式化时间戳为 HH:MM
+    const messageTime = new Date(timestamp).toLocaleString("zh-CN", {
+        timeZone: "Asia/Shanghai",
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false,
+    });
+
+    let builtinPrompt = "";
+
+    // 【首次对话】显示详细信息
+    console.info(`[qqbot:system-prompt] ${conversationId}:${isNewConversation}`);
+    if (isNewConversation) {
+        builtinPrompt = `
+【新会话】用户: ${senderName || senderId} (ID: ${senderId}) | ${isGroupChat ? "QQ群聊" : "QQ私聊"}
+
+【可用能力】
+• 定时提醒 - 使用 openclaw cron add --at "5m" --message "内容" --to "${targetAddress}"
+• 发送图片 - <qqimg>路径</qqimg>
+
+【当前用户信息】
+- 用户 openid: ${senderId}
+- 用户昵称: ${senderName || "未知"}
+- 消息类型: ${isGroupChat ? "群聊" : "私聊"}
+- 当前消息 message_id: ${messageId}${isGroupChat ? `
+- 群组 group_openid: ${groupOpenid}` : ""}
+
+【定时提醒能力详解】
+你可以帮助用户设置定时提醒。使用exec工具运行 openclaw cron 命令：
+示例：5分钟后提醒用户喝水
+\`\`\`bash
+openclaw cron add \\
+  --name "提醒喝水-${senderName || "用户"}" \\
+  --at "5m" \\
+  --session isolated \\
+  --message "💧 该喝水啦！" \\
+  --deliver \\
+  --channel qqbot \\
+  --to "${targetAddress}" \\
+  --delete-after-run
+\`\`\`
+
+关键参数说明：
+- \`--to\`: 目标地址（当前用户: ${targetAddress}）
+- \`--at\`: 一次性定时任务的触发时间
+  - 相对时间格式：数字+单位，如 \`5m\`（5分钟）、\`1h\`（1小时）、\`2d\`（2天）【注意：不要加 + 号】
+  - 绝对时间格式：ISO 8601 带时区，如 \`2026-02-01T14:00:00+08:00\`
+- \`--cron\`: 周期性任务（如 \`0 8 * * *\` 每天早上8点）
+- \`--tz "Asia/Shanghai"\`: 周期任务务必设置时区
+- \`--delete-after-run\`: 一次性任务必须添加此参数
+- \`--message\`: 消息内容（必填，不能为空！这是定时提醒触发时直接发送给用户的内容）
+- \`--session isolated\` 独立会话任务
+
+重要注意事项：
+1. --at 参数格式：相对时间用 \`5m\`、\`1h\` 等（不要加 + 号！）；绝对时间用完整 ISO 格式
+2. --message 参数必须有实际内容，不能为空字符串
+3. cron add 命令不支持 --reply-to 参数，定时提醒只能作为主动消息发送
+
+【发送图片功能】
+你可以直接发送图片给用户！使用 <qqimg> 标签包裹图片路径：
+
+<qqimg>图片路径</qqimg>
+
+示例：
+- <qqimg>/Users/xxx/images/photo.jpg</qqimg>  （本地文件）
+- <qqimg>https://example.com/image.png</qqimg>  （网络图片）
+
+注意：
+- 必须使用 <qqimg>路径</qqimg> 格式
+- 本地路径必须是绝对路径，支持 png、jpg、jpeg、gif、webp 格式
+- 图片文件/URL 必须有效，否则发送失败
+- Markdown格式下，也必须使用该方式发送图片`;
+    }
+
+
+    // 【后续对话】显示精简信息
+    else {
+        builtinPrompt = `
+【继续活跃会话】${senderName} | ${senderId} | ${messageTime}
+
+【可用指令提示】需要时使用: openclaw cron add --at "5m" --message "内容" --to "${targetAddress}"
+
+【可用图片能力】<qqimg>路径</qqimg>`;
+
+    }
+
+    return builtinPrompt;
+}
+


### PR DESCRIPTION
`add file path: 03:59:07 info [qqbot-CONVERSATION_DIR] = /Users/XXX/clawd/qqbot-data
`

**第一次会话：**
03:59:12 info gateway/channels/qqbot {"subsystem":"gateway/channels/qqbot"} [qqbot:default] messageBody: 【系统提示】

【新会话】用户: XXX (ID: XXX) | QQ私聊
【可用能力】
• 定时提醒 - 使用 openclaw cron add --at "5m" --message "内容" --to "XXX"
• 发送图片 - <qqimg>路径</qqimg>

【当前用户信息】
- 用户 openid: 3901976869E30F1F4329AC33DA251F37
- 用户昵称: 未知
- 消息类型: 私聊
- 当前消息 message_id: ROBOT1.0_flaYRETRfFmAJatmEnwVziTgkNbFSouahtfeU6NH16dcSJD8IvQhf.yUbx8YcRFLplSstt8Qt8nJcZVWYzHU3lKTBl0bDXXBybve5OK.Tdk!

【定时提醒能力详解】
你可以帮助用户设置定时提醒。使用exec工具运行 openclaw cron 命令：
示例：5分钟后提醒用户喝水
```bash
openclaw cron add \
  --name "提醒喝水-用户" \
  --at "5m" \
  --session isolated \
  --message "💧 该喝水啦！" \
  --deliver \
  --channel qqbot \
  --to "XXX" \
  --delete-after-run
```

关键参数说明：
- `--to`: 目标地址（当前用户: XXX）
- `--at`: 一次性定时任务的触发时间
  - 相对时间格式：数字+单位，如 `5m`（5分钟）、`1h`（1小时）、`2d`（2天）【注意：不要加 + 号】
  - 绝对时间格式：ISO 8601 带时区，如 `2026-02-01T14:00:00+08:00`
- `--cron`: 周期性任务（如 `0 8 * * *` 每天早上8点）
- `--tz "Asia/Shanghai"`: 周期任务务必设置时区
- `--delete-after-run`: 一次性任务必须添加此参数
- `--message`: 消息内容（必填，不能为空！这是定时提醒触发时直接发送给用户的内容）
- `--session isolated` 独立会话任务

重要注意事项：
1. --at 参数格式：相对时间用 `5m`、`1h` 等（不要加 + 号！）；绝对时间用完整 ISO 格式
2. --message 参数必须有实际内容，不能为空字符串
3. cron add 命令不支持 --reply-to 参数，定时提醒只能作为主动消息发送

【发送图片功能】
你可以直接发送图片给用户！使用 <qqimg> 标签包裹图片路径：

<qqimg>图片路径</qqimg>

示例：
- <qqimg>/Users/xxx/images/photo.jpg</qqimg>  （本地文件）
- <qqimg>https://example.com/image.png</qqimg>  （网络图片）

注意：
- 必须使用 <qqimg>路径</qqimg> 格式
- 本地路径必须是绝对路径，支持 png、jpg、jpeg、gif、webp 格式
- 图片文件/URL 必须有效，否则发送失败
- Markdown格式下，也必须使用该方式发送图片

【用户输入】
重新发起第一次

**第二次会话：**
03:59:53 info gateway/channels/qqbot {"subsystem":"gateway/channels/qqbot"} [qqbot:default] messageBody: 【系统提示】
【继续活跃会话】XXX | 11:59
【可用指令提示】需要时使用: openclaw cron add --at "5m" --message "内容" --to "XXX"
【可用图片能力】<qqimg>路径</qqimg>
【用户输入】
第二次~