### PR TITLE
fix: issue#55 openclaw message send 报错 Error: to required

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -76,7 +76,7 @@ export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
     normalizeTarget: (target) => {
       // 支持格式: qqbot:c2c:xxx, qqbot:group:xxx, c2c:xxx, group:xxx, openid
       const normalized = target.replace(/^qqbot:/i, "");
-      return { ok: true, to: normalized };
+      return normalized || undefined;
     },
     targetResolver: {
       looksLikeId: (id) => {

--- a/src/openclaw-plugin-sdk.d.ts
+++ b/src/openclaw-plugin-sdk.d.ts
@@ -195,19 +195,10 @@ declare module "openclaw/plugin-sdk" {
   }
 
   /**
-   * 消息目标解析结果
-   */
-  export interface NormalizeTargetResult {
-    ok: boolean;
-    to?: string;
-    error?: string;
-  }
-
-  /**
    * 目标解析器
    */
   export interface TargetResolver {
-    looksLikeId?: (id: string) => boolean;
+    looksLikeId?: (id: string, normalized?: string) => boolean;
     hint?: string;
   }
 
@@ -215,7 +206,7 @@ declare module "openclaw/plugin-sdk" {
    * 频道插件 Messaging 接口
    */
   export interface ChannelPluginMessaging {
-    normalizeTarget?: (target: string) => NormalizeTargetResult;
+    normalizeTarget?: (target: string) => string | undefined;
     targetResolver?: TargetResolver;
     [key: string]: unknown;
   }


### PR DESCRIPTION
# 修复：QQ Bot 消息发送失败，提示 "Error: to required"

## 问题描述

使用 QQ Bot 通道执行 `openclaw message send` 命令时，出现以下错误：
```
Error: to required
```

失败的示例命令：
```bash
openclaw message send --channel qqbot --target "AXXXXXXXXXXXXXX1231XXXX(openid)" --message "测试消息"
```

## 根本原因分析

该问题是由于 QQ Bot 的 `normalizeTarget` 实现与 OpenClaw SDK 期望的接口之间存在**类型不匹配**导致的。

### OpenClaw SDK 类型定义
在 `/opt/openclaw/src/channels/plugins/types.core.ts` 中：
```typescript
export type ChannelMessagingAdapter = {
  normalizeTarget?: (raw: string) => string | undefined;
  // ...
};
```

### QQ Bot 的错误实现
在 `/home/admin/.openclaw/extensions/qqbot/src/channel.ts` 中：
```typescript
normalizeTarget: (target) => {
  const normalized = target.replace(/^qqbot:/i, "");
  return { ok: true, to: normalized };  // ❌ 返回对象而非字符串
},
```

### QQ Bot 的错误类型定义
在 `/home/admin/.openclaw/extensions/qqbot/src/openclaw-plugin-sdk.d.ts` 中：
```typescript
export interface NormalizeTargetResult {
  ok: boolean;
  to?: string;
  error?: string;
}

export interface ChannelPluginMessaging {
  normalizeTarget?: (target: string) => NormalizeTargetResult;  // ❌ 错误的返回类型
  // ...
}
```

当 OpenClaw 调用 `normalizeTargetForProvider()` 时，它期望返回 `string | undefined`，但 QQ Bot 返回的是一个对象 `{ ok: true, to: normalized }`。这导致目标解析静默失败，`to` 参数未能正确设置。

此外没有检查到任何实际功能依赖该对象的ok 和 error 字段。

## 解决方案

### 1. 修复类型定义 (`src/openclaw-plugin-sdk.d.ts`)

移除错误的 `NormalizeTargetResult` 接口，并更新 `ChannelPluginMessaging`：

```typescript
// 修改前：
export interface NormalizeTargetResult {
  ok: boolean;
  to?: string;
  error?: string;
}

export interface ChannelPluginMessaging {
  normalizeTarget?: (target: string) => NormalizeTargetResult;
  targetResolver?: TargetResolver;
  [key: string]: unknown;
}

// 修改后：
export interface ChannelPluginMessaging {
  normalizeTarget?: (target: string) => string | undefined;
  targetResolver?: TargetResolver;
  [key: string]: unknown;
}
```

同时更新 `TargetResolver.looksLikeId` 的签名以匹配 SDK：
```typescript
// 修改前：
looksLikeId?: (id: string) => boolean;

// 修改后：
looksLikeId?: (id: string, normalized?: string) => boolean;
```

### 2. 修复实现 (`src/channel.ts`)

更新 `normalizeTarget` 使其返回字符串而非对象：

```typescript
// 修改前：
normalizeTarget: (target) => {
  const normalized = target.replace(/^qqbot:/i, "");
  return { ok: true, to: normalized };
},

// 修改后：
normalizeTarget: (target) => {
  const normalized = target.replace(/^qqbot:/i, "");
  return normalized || undefined;
},
```

## 验证

修复并重新编译后，消息发送命令可以正常工作：

```bash
$ openclaw message send --channel qqbot --target "AXXXXXXXXXXXXXX1231XXXX(openid)" --message "测试消息"
✅ Sent via QQ Bot. Message ID: xxxx!!
```

## 变更文件

1. `src/openclaw-plugin-sdk.d.ts` - 修复类型定义以匹配 OpenClaw SDK
2. `src/channel.ts` - 修复 `normalizeTarget` 实现以返回正确的类型

## 影响

此修复解决了 QQ Bot 无法通过 `openclaw message send` CLI 命令或 message 工具 API 发送消息的破坏性 issue。 #55 
该issue还会导致openclaw定时任务能够执行但无法将结果发送到qq。 #93 #81 