### PR TITLE
fix: detect audio format from file header for STT upload

### DIFF
--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -71,10 +71,29 @@ async function transcribeAudio(audioPath: string, cfg: Record<string, unknown>):
   if (!sttCfg) return null;
 
   const fileBuffer = fs.readFileSync(audioPath);
-  const fileName = sanitizeFileName(path.basename(audioPath));
+  let fileName = sanitizeFileName(path.basename(audioPath));
+
+  // Detect actual audio format from file header (magic bytes) to fix incorrect
+  // extensions.  When voice_wav_url is downloaded without an originalFilename,
+  // downloadFile() saves it as "<hash>.bin".  Most cloud STT APIs (Groq, OpenAI,
+  // etc.) reject files whose extension is not in their allowlist, so we must
+  // correct the extension before uploading.
+  const hdr = fileBuffer.subarray(0, 12);
+  const hdrStr = hdr.toString("ascii");
+  if (hdrStr.startsWith("RIFF") && hdrStr.slice(8, 12) === "WAVE") {
+    if (!fileName.endsWith(".wav")) fileName = fileName.replace(/\.[^.]+$/, ".wav");
+  } else if (hdr[0] === 0xff && (hdr[1] & 0xe0) === 0xe0) {
+    if (!fileName.endsWith(".mp3")) fileName = fileName.replace(/\.[^.]+$/, ".mp3");
+  } else if (hdrStr.startsWith("OggS")) {
+    if (!fileName.endsWith(".ogg")) fileName = fileName.replace(/\.[^.]+$/, ".ogg");
+  } else if (hdrStr.startsWith("fLaC")) {
+    if (!fileName.endsWith(".flac")) fileName = fileName.replace(/\.[^.]+$/, ".flac");
+  }
+
   const mime = fileName.endsWith(".wav") ? "audio/wav"
     : fileName.endsWith(".mp3") ? "audio/mpeg"
     : fileName.endsWith(".ogg") ? "audio/ogg"
+    : fileName.endsWith(".flac") ? "audio/flac"
     : "application/octet-stream";
 
   const form = new FormData();


### PR DESCRIPTION
## Problem

When `voice_wav_url` is downloaded via `downloadFile()` without an `originalFilename`, the file is saved as `<hash>.bin`. The `transcribeAudio()` function then uses this filename directly when uploading to the STT API.

Cloud STT providers like **Groq** and **OpenAI** validate file extensions and reject `.bin` files with an error like:

```
file must be one of the following types: [flac mp3 mp4 mpeg mpga m4a ogg opus wav webm]
```

This causes all voice message transcriptions to fail when using these providers.

## Fix

Read the file header (magic bytes) in `transcribeAudio()` to detect the actual audio format and correct the filename extension before uploading:

- `RIFF...WAVE` → `.wav`
- `0xFF 0xE0+` → `.mp3`
- `OggS` → `.ogg`
- `fLaC` → `.flac`

## Testing

Verified with Groq `whisper-large-v3-turbo`:
- Before fix: `file must be one of the following types: [flac mp3 mp4 ...]`
- After fix: transcription works correctly

## Alternative

A more upstream fix would be to have `downloadFile()` detect the content type from the HTTP response headers or file content and use the correct extension when saving. But the magic-bytes approach in `transcribeAudio()` is a safe, minimal fix that works regardless of how the file was saved.