### PR TITLE
feat: add markdown-aware message chunker and configurable block streaming

### DIFF
--- a/src/channel.ts
+++ b/src/channel.ts
@@ -12,40 +12,7 @@ import { sendText, sendMedia } from "./outbound.js";
 import { startGateway } from "./gateway.js";
 import { qqbotOnboardingAdapter } from "./onboarding.js";
 import { getQQBotRuntime } from "./runtime.js";
-
-/**
- * 简单的文本分块函数
- * 用于预先分块长文本
- */
-function chunkText(text: string, limit: number): string[] {
-  if (text.length <= limit) return [text];
-  
-  const chunks: string[] = [];
-  let remaining = text;
-  
-  while (remaining.length > 0) {
-    if (remaining.length <= limit) {
-      chunks.push(remaining);
-      break;
-    }
-    
-    // 尝试在换行处分割
-    let splitAt = remaining.lastIndexOf("\n", limit);
-    if (splitAt <= 0 || splitAt < limit * 0.5) {
-      // 没找到合适的换行，尝试在空格处分割
-      splitAt = remaining.lastIndexOf(" ", limit);
-    }
-    if (splitAt <= 0 || splitAt < limit * 0.5) {
-      // 还是没找到，强制在 limit 处分割
-      splitAt = limit;
-    }
-    
-    chunks.push(remaining.slice(0, splitAt));
-    remaining = remaining.slice(splitAt).trimStart();
-  }
-  
-  return chunks;
-}
+import { chunkText } from "./utils/chunk-helper.js";
 
 export const qqbotPlugin: ChannelPlugin<ResolvedQQBotAccount> = {
   id: "qqbot",

--- a/src/config.ts
+++ b/src/config.ts
@@ -82,6 +82,7 @@ export function resolveQQBotAccount(
       systemPrompt: qqbot?.systemPrompt,
       imageServerBaseUrl: qqbot?.imageServerBaseUrl,
       markdownSupport: qqbot?.markdownSupport ?? true,
+      blockStreaming: qqbot?.blockStreaming ?? true,
     };
     appId = normalizeAppId(qqbot?.appId);
   } else {
@@ -118,6 +119,7 @@ export function resolveQQBotAccount(
     systemPrompt: accountConfig.systemPrompt,
     imageServerBaseUrl: accountConfig.imageServerBaseUrl || process.env.QQBOT_IMAGE_SERVER_BASE_URL,
     markdownSupport: accountConfig.markdownSupport !== false,
+    blockStreaming: accountConfig.blockStreaming !== false,
     config: accountConfig,
   };
 }

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -8,6 +8,7 @@ import { recordKnownUser, flushKnownUsers } from "./known-users.js";
 import { getQQBotRuntime } from "./runtime.js";
 import { startImageServer, isImageServerRunning, downloadFile, type ImageServerConfig } from "./image-server.js";
 import { getImageSize, formatQQBotMarkdownImage, hasQQBotImageSize, DEFAULT_IMAGE_SIZE } from "./utils/image-size.js";
+import { chunkText } from "./utils/chunk-helper.js";
 import { parseQQBotPayload, encodePayloadForCron, isCronReminderPayload, isMediaPayload, type CronReminderPayload, type MediaPayload } from "./utils/payload.js";
 import { convertSilkToWav, isVoiceAttachment, formatDuration, resolveTTSConfig, textToSilk, audioFileToSilkBase64, waitForFile, isAudioFile } from "./utils/audio-convert.js";
 import { normalizeMediaTags } from "./utils/media-tags.js";
@@ -2269,17 +2270,34 @@ ${ttsHint}${sttHint}${asrFallbackHint}${voiceForwardHint}`;
                   // 🔹 第三步：发送带公网图片的 markdown 消息
                   if (textWithoutImages.trim()) {
                     try {
-                      await sendWithTokenRetry(async (token) => {
-                        const ref = consumeQuoteRef();
-                        if (event.type === "c2c") {
-                          await sendC2CMessage(token, event.senderId, textWithoutImages, event.messageId, ref);
-                        } else if (event.type === "group" && event.groupOpenid) {
-                          await sendGroupMessage(token, event.groupOpenid, textWithoutImages, event.messageId, ref);
-                        } else if (event.channelId) {
-                          await sendChannelMessage(token, event.channelId, textWithoutImages, event.messageId, ref);
+                      if (account.blockStreaming) {
+                        await sendWithTokenRetry(async (token) => {
+                          const ref = consumeQuoteRef();
+                          if (event.type === "c2c") {
+                            await sendC2CMessage(token, event.senderId, textWithoutImages, event.messageId, ref);
+                          } else if (event.type === "group" && event.groupOpenid) {
+                            await sendGroupMessage(token, event.groupOpenid, textWithoutImages, event.messageId, ref);
+                          } else if (event.channelId) {
+                            await sendChannelMessage(token, event.channelId, textWithoutImages, event.messageId, ref);
+                          }
+                        });
+                        log?.info(`[qqbot:${account.accountId}] Sent markdown message with ${httpImageUrls.length} HTTP images (${event.type})`);
+                      } else {
+                        const textChunks = chunkText(textWithoutImages, 2000);
+                        for (const chunk of textChunks) {
+                          await sendWithTokenRetry(async (token) => {
+                            const ref = consumeQuoteRef();
+                            if (event.type === "c2c") {
+                              await sendC2CMessage(token, event.senderId, chunk, event.messageId, ref);
+                            } else if (event.type === "group" && event.groupOpenid) {
+                              await sendGroupMessage(token, event.groupOpenid, chunk, event.messageId, ref);
+                            } else if (event.channelId) {
+                              await sendChannelMessage(token, event.channelId, chunk, event.messageId, ref);
+                            }
+                          });
                         }
-                      });
-                      log?.info(`[qqbot:${account.accountId}] Sent markdown message with ${httpImageUrls.length} HTTP images (${event.type})`);
+                        log?.info(`[qqbot:${account.accountId}] Sent markdown message with ${httpImageUrls.length} HTTP images (${event.type}), chunks: ${textChunks.length}`);
+                      }
                     } catch (err) {
                       log?.error(`[qqbot:${account.accountId}] Failed to send markdown message: ${err}`);
                     }
@@ -2321,17 +2339,34 @@ ${ttsHint}${sttHint}${asrFallbackHint}${voiceForwardHint}`;
 
                     // 发送文本消息
                     if (textWithoutImages.trim()) {
-                      await sendWithTokenRetry(async (token) => {
-                        const ref = consumeQuoteRef();
-                        if (event.type === "c2c") {
-                          await sendC2CMessage(token, event.senderId, textWithoutImages, event.messageId, ref);
-                        } else if (event.type === "group" && event.groupOpenid) {
-                          await sendGroupMessage(token, event.groupOpenid, textWithoutImages, event.messageId, ref);
-                        } else if (event.channelId) {
-                          await sendChannelMessage(token, event.channelId, textWithoutImages, event.messageId, ref);
+                      if (account.blockStreaming) {
+                        await sendWithTokenRetry(async (token) => {
+                          const ref = consumeQuoteRef();
+                          if (event.type === "c2c") {
+                            await sendC2CMessage(token, event.senderId, textWithoutImages, event.messageId, ref);
+                          } else if (event.type === "group" && event.groupOpenid) {
+                            await sendGroupMessage(token, event.groupOpenid, textWithoutImages, event.messageId, ref);
+                          } else if (event.channelId) {
+                            await sendChannelMessage(token, event.channelId, textWithoutImages, event.messageId, ref);
+                          }
+                        });
+                        log?.info(`[qqbot:${account.accountId}] Sent text reply (${event.type})`);
+                      } else {
+                        const textChunks = chunkText(textWithoutImages, 2000);
+                        for (const chunk of textChunks) {
+                          await sendWithTokenRetry(async (token) => {
+                            const ref = consumeQuoteRef();
+                            if (event.type === "c2c") {
+                              await sendC2CMessage(token, event.senderId, chunk, event.messageId, ref);
+                            } else if (event.type === "group" && event.groupOpenid) {
+                              await sendGroupMessage(token, event.groupOpenid, chunk, event.messageId, ref);
+                            } else if (event.channelId) {
+                              await sendChannelMessage(token, event.channelId, chunk, event.messageId, ref);
+                            }
+                          });
                         }
-                      });
-                      log?.info(`[qqbot:${account.accountId}] Sent text reply (${event.type})`);
+                        log?.info(`[qqbot:${account.accountId}] Sent text reply (${event.type}), chunks: ${textChunks.length}`);
+                      }
                     }
                   } catch (err) {
                     log?.error(`[qqbot:${account.accountId}] Send failed: ${err}`);
@@ -2362,7 +2397,7 @@ ${ttsHint}${sttHint}${asrFallbackHint}${voiceForwardHint}`;
               },
             },
             replyOptions: {
-              disableBlockStreaming: false,
+              disableBlockStreaming: !account.blockStreaming,
             },
           });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,8 @@ export interface ResolvedQQBotAccount {
   imageServerBaseUrl?: string;
   /** 是否支持 markdown 消息（默认 true） */
   markdownSupport: boolean;
+  /** 是否启用块流式响应（默认 true，即按段落逐步发送，保持向后兼容） */
+  blockStreaming: boolean;
   config: QQBotAccountConfig;
 }
 
@@ -43,6 +45,12 @@ export interface QQBotAccountConfig {
   imageServerBaseUrl?: string;
   /** 是否支持 markdown 消息（默认 true，设为 false 可禁用） */
   markdownSupport?: boolean;
+  /**
+   * 是否启用块流式响应（默认 true）
+   * true: AI 生成过程中按段落逐步发送，响应更快（默认，保持向后兼容）
+   * false: 等待完整回复后一次性发送，支持正确的分块和媒体标签处理
+   */
+  blockStreaming?: boolean;
   /**
    * @deprecated 请使用 audioFormatPolicy.uploadDirectFormats
    * 可直接上传的音频格式（不转换为 SILK），向后兼容

--- a/src/utils/chunk-helper.ts
+++ b/src/utils/chunk-helper.ts
@@ -1,0 +1,157 @@
+/**
+ * Markdown 文本分块器
+ *
+ * 按行遍历文本，在代码块边界自动闭合/重开，在表格边界补全表头。
+ * 所有长度判断使用 UTF-8 字节数（QQ API 按字节截断）。
+ */
+
+import { Buffer } from "node:buffer";
+
+/** 表格分隔行正则，匹配如 |---|---| 或 | :---: | ---: | 等 */
+const TABLE_SEP_RE = /^\|[\s\-:|]+\|$/;
+/** 代码块闭合重开所需的固定开销字节数：换行符 + ``` */
+const FENCE_FIXED_LEN = 4;
+
+/** 计算字符串的 UTF-8 字节长度 */
+function byteLen(str: string): number {
+  return Buffer.byteLength(str, "utf-8");
+}
+
+/** 判断一行是否为表格分隔行 */
+function isTableSepLine(line: string): boolean {
+  const t = line.trim();
+  return t.startsWith("|") && TABLE_SEP_RE.test(t);
+}
+
+/**
+ * 从分隔行（sepIdx）的下一行开始向下扫描，
+ * 返回所有数据行的字节总数（含换行符）。
+ * 遇到空行或非管道行时停止，表示表格结束。
+ */
+function measureTable(lines: string[], sepIdx: number): number {
+  let bytes = 0;
+  for (let i = sepIdx + 1; i < lines.length; i++) {
+    const line = lines[i];
+    // 非管道行或空行，表格结束
+    if (line.trim() === "" || !line.trim().startsWith("|")) break;
+    bytes += byteLen(line) + 1;
+  }
+  return bytes;
+}
+
+/** 分块过程中的可变状态 */
+interface ChunkContext {
+  chunks: string[];
+  inCode: boolean;
+  lang: string;
+  tableHeader: string | null;
+  current: string;
+}
+
+/**
+ * 产出当前块并初始化新块。
+ * - 若在代码块内，先闭合当前块（追加 \n```），再在新块头部重开（```lang\n）
+ * - 若存在 tableHeader，补全到新块头部（前提是不超过 limit）
+ */
+function finishChunk(ctx: ChunkContext, limit: number): void {
+  if (!ctx.current) return;
+  if (ctx.inCode) ctx.current += "\n```";
+  ctx.chunks.push(ctx.current);
+  ctx.current = "";
+  if (ctx.inCode) ctx.current = "```" + ctx.lang;
+  if (ctx.tableHeader && !ctx.inCode) {
+    if (byteLen(ctx.tableHeader) + 1 <= limit) {
+      ctx.current += ctx.tableHeader;
+    }
+  }
+}
+
+/**
+ * 检测表格起始（表头行 + 分隔行），向前扫描整个表格大小来决定是否提前分割。
+ * - 表格能完整放入当前块 → 不分割
+ * - 当前块放不下但表格本身不超过 limit → 提前 finishChunk，让表格在新块中保持完整
+ * - 表格本身超过 limit → 不提前分割，交由主循环的 wouldExceed 做 mid-table 分割（并补全表头）
+ */
+function trySplitTable(
+  ctx: ChunkContext,
+  line: string,
+  nextLine: string | undefined,
+  sepIdx: number,
+  lines: string[],
+  limit: number,
+): void {
+  if (ctx.inCode || !line.includes("|") || !nextLine) return;
+  if (!isTableSepLine(nextLine)) return;
+  ctx.tableHeader = null;
+  const headerBytes = byteLen(line) + 1 + byteLen(nextLine) + 1;
+  const tableBytes = headerBytes + measureTable(lines, sepIdx);
+  if (
+    ctx.current &&
+    tableBytes < limit &&
+    byteLen(ctx.current) + tableBytes > limit
+  ) {
+    finishChunk(ctx, limit);
+  }
+}
+
+/**
+ * 遇到 ``` 开头的行时切换代码块开启/闭合状态。
+ * 闭合时清除 lang 和 tableHeader；开启时记录语言标识。
+ */
+function updateFenceState(ctx: ChunkContext, line: string): void {
+  const fenced = line.match(/^```(\S*)/);
+  if (!fenced) return;
+  if (ctx.inCode) {
+    ctx.inCode = false;
+    ctx.lang = "";
+    // 离开代码块，清除残留表头
+    ctx.tableHeader = null;
+  } else {
+    ctx.inCode = true;
+    ctx.lang = fenced[1];
+  }
+}
+
+/**
+ * 将 Markdown 文本按字节限制分块。
+ * 保证代码块在分块边界处正确闭合/重开，表格在分块边界处补全表头。
+ */
+export function chunkText(text: string, limit: number): string[] {
+  if (byteLen(text) <= limit) return [text];
+
+  const lines = text.split("\n");
+  const ctx: ChunkContext = {
+    chunks: [],
+    inCode: false,
+    lang: "",
+    tableHeader: null,
+    current: "",
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    // 尝试在表头处提前分割
+    trySplitTable(ctx, line, lines[i + 1], i + 1, lines, limit);
+
+    // 预留代码块闭合开销，判断追加当前行是否会超限
+    const closeOverhead = ctx.inCode ? FENCE_FIXED_LEN : 0;
+    const wouldExceed = byteLen(ctx.current) + byteLen(line) + 1 + closeOverhead > limit;
+    if (wouldExceed && ctx.current) finishChunk(ctx, limit);
+
+    ctx.current += ctx.current ? "\n" + line : line;
+    if (!ctx.inCode && isTableSepLine(line) && i > 0 && lines[i - 1].includes("|")) {
+      ctx.tableHeader = lines[i - 1] + "\n" + line;
+    } else if (!ctx.inCode && !line.includes("|")) {
+      ctx.tableHeader = null;
+    }
+    updateFenceState(ctx, line);
+  }
+
+  // 产出最后一块
+  if (ctx.current) {
+    if (ctx.inCode) ctx.current += "\n```";
+    ctx.chunks.push(ctx.current);
+  }
+
+  return ctx.chunks;
+}


### PR DESCRIPTION
- Add chunk-helper.ts with UTF-8 byte-length aware splitting
- Handle code block fence open/close across chunk boundaries
- Preserve table headers when splitting mid-table
- Replace naive chunkText in channel.ts with the new chunker
- Add blockStreaming config (default true, backward compatible)
- When blockStreaming is off, apply chunkText to gateway text delivery

Fixes #131 

增加非流式分块情况下代码块和表格内容的渲染，默认兼容目前版本
优点：代码块分块后能正常闭合标签渲染，长表格分块后自动补齐表头
缺点：回答完后一次性发送，稍微增加回答延时