### PR TITLE
feat: add message preprocessor API for plugin integration

### DIFF
--- a/docs/message-preprocessor.md
+++ b/docs/message-preprocessor.md
@@ -1,0 +1,156 @@
+# Message Preprocessor API
+
+This document describes the message preprocessor feature added to the qqbot gateway.
+
+## Overview
+
+The message preprocessor provides a "fast lane" for messages that need immediate processing, bypassing the per-user serial message queue.
+
+## The Problem It Solves
+
+### Deadlock Scenario
+
+When a plugin (like `sudo-control`) needs user approval before executing a command:
+
+```
+User sends: "execute sudo ls /root"
+    → Message enters queue
+    → AI processes it
+    → Plugin sends approval request via QQ
+    → Plugin awaits response (Promise pending)
+    → User's queue is now blocked
+
+User replies: "批准 sudo-xxx"
+    → Message enters queue
+    → BUT: Previous message is still being processed
+    → Queue waits for previous message to complete
+    → Previous message is waiting for user reply
+    → DEADLOCK → Timeout after 5 minutes
+```
+
+### The Solution
+
+Preprocessors run **before** messages enter the queue, allowing approval responses to resolve the pending Promise immediately:
+
+```
+User replies: "批准 sudo-xxx"
+    → Preprocessor matches the pattern
+    → Directly resolves the Promise
+    → Returns true (message handled, don't enqueue)
+    → No deadlock!
+```
+
+## API
+
+### Types
+
+```typescript
+// Message structure passed to preprocessors
+export interface QueuedMessage {
+  type: "c2c" | "guild" | "dm" | "group";
+  senderId: string;
+  senderName?: string;
+  content: string;
+  messageId: string;
+  timestamp: string;
+  channelId?: string;
+  guildId?: string;
+  groupOpenid?: string;
+  attachments?: Array<{ content_type: string; url: string; filename?: string }>;
+  refMsgIdx?: string;
+  msgIdx?: string;
+}
+
+// Preprocessor function signature
+export type MessagePreprocessor = (msg: QueuedMessage) => boolean;
+```
+
+### Functions
+
+#### `registerMessagePreprocessor(fn: MessagePreprocessor): () => void`
+
+Registers a message preprocessor. Returns an unregister function.
+
+**Parameters:**
+- `fn` - Preprocessor function that receives the message
+  - Returns `true` to intercept the message (don't enqueue)
+  - Returns `false` to continue normal processing
+
+**Returns:**
+- Unregister function
+
+### Usage Example
+
+```typescript
+import { registerMessagePreprocessor, type QueuedMessage } from './gateway.js';
+
+// Register preprocessor
+const unregister = registerMessagePreprocessor((msg: QueuedMessage) => {
+  const content = msg.content.trim();
+
+  // Handle approval responses
+  if (content.startsWith('批准 sudo-')) {
+    const requestId = content.split(' ')[1];
+    resolveApproval(requestId, true);
+    return true; // Message handled, don't enqueue
+  }
+
+  if (content.startsWith('拒绝 sudo-')) {
+    const requestId = content.split(' ')[1];
+    resolveApproval(requestId, false);
+    return true;
+  }
+
+  return false; // Continue normal processing
+});
+
+// Later: unregister if no longer needed
+unregister();
+```
+
+## Other Use Cases
+
+| Use Case | Description |
+|----------|-------------|
+| **Emergency Stop** | `/abort` command to immediately cancel operations |
+| **Quick Status** | `/ping`, `/uptime` for instant responses without AI |
+| **Background Commands** | `>>backup` to trigger actions without interrupting chat |
+| **Message Filtering** | Block spam or blacklist users before processing |
+| **2FA Verification** | Handle verification codes without queuing |
+| **Message Routing** | Route to different agents based on prefix |
+
+## Design Principles
+
+1. **Sync Only** - Preprocessors must be synchronous and fast
+2. **No Blocking** - Avoid heavy operations that could block WebSocket heartbeat
+3. **Error Handling** - Errors are caught and logged, processing continues
+4. **Shared Scope** - Preprocessors are shared across all accounts
+
+## Performance Impact
+
+- **Empty preprocessor list**: Zero overhead (empty array iteration)
+- **With preprocessors**: Minimal overhead (one function call per message)
+- **Preprocessor errors**: Caught and logged, message continues to queue
+
+## Migration Guide
+
+For plugin authors who want to use this feature:
+
+1. Import the gateway module:
+   ```typescript
+   const gateway = await import('path/to/qqbot/src/gateway.js');
+   ```
+
+2. Check if the feature is available:
+   ```typescript
+   if (typeof gateway.registerMessagePreprocessor === 'function') {
+     // Feature available
+   }
+   ```
+
+3. Register your preprocessor during plugin initialization
+
+## Changelog
+
+- **v1.7.0**: Added `registerMessagePreprocessor()` API
+- **v1.7.0**: Exported `QueuedMessage` interface

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -292,7 +292,7 @@ export interface GatewayContext {
 /**
  * 消息队列项类型（用于异步处理消息，防止阻塞心跳）
  */
-interface QueuedMessage {
+export interface QueuedMessage {
   type: "c2c" | "guild" | "dm" | "group";
   senderId: string;
   senderName?: string;
@@ -307,6 +307,57 @@ interface QueuedMessage {
   refMsgIdx?: string;
   /** 当前消息自身的 refIdx（供将来被引用） */
   msgIdx?: string;
+}
+
+/**
+ * 消息预处理器类型
+ *
+ * 预处理器在消息入队之前被调用，可以用于：
+ * - 实现快速响应通道（绕过串行队列）
+ * - 解决死锁问题（如审批响应）
+ * - 消息过滤、路由等
+ *
+ * @param msg - 待处理的消息
+ * @returns true 表示消息已被处理，不入队；false 表示继续正常入队
+ *
+ * @example
+ * // 注册审批响应预处理器
+ * registerMessagePreprocessor((msg) => {
+ *   if (msg.content.startsWith('批准 sudo-')) {
+ *     handleApproval(msg.content);
+ *     return true; // 已处理，不入队
+ *   }
+ *   return false; // 继续正常处理
+ * });
+ */
+export type MessagePreprocessor = (msg: QueuedMessage) => boolean;
+
+// 模块级预处理器列表（所有账户共享）
+const messagePreprocessors: MessagePreprocessor[] = [];
+
+/**
+ * 注册消息预处理器
+ *
+ * 预处理器按注册顺序执行，任一预处理器返回 true 即停止处理。
+ *
+ * @param fn - 预处理器函数
+ * @returns 取消注册的函数
+ *
+ * @example
+ * const unregister = registerMessagePreprocessor((msg) => {
+ *   // 处理紧急消息
+ *   return false;
+ * });
+ *
+ * // 不再需要时取消注册
+ * unregister();
+ */
+export function registerMessagePreprocessor(fn: MessagePreprocessor): () => void {
+  messagePreprocessors.push(fn);
+  return () => {
+    const idx = messagePreprocessors.indexOf(fn);
+    if (idx >= 0) messagePreprocessors.splice(idx, 1);
+  };
 }
 
 /**
@@ -502,15 +553,27 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
   };
 
   const enqueueMessage = (msg: QueuedMessage): void => {
+    // 1. 预处理器快速通道（在入队之前执行）
+    for (const preprocessor of messagePreprocessors) {
+      try {
+        if (preprocessor(msg)) {
+          log?.info(`[qqbot:${account.accountId}] Message intercepted by preprocessor: ${msg.content?.substring(0, 60)}`);
+          return; // 已处理，不入队
+        }
+      } catch (err) {
+        log?.error(`[qqbot:${account.accountId}] Message preprocessor error: ${err}`);
+      }
+    }
+
     const peerId = getMessagePeerId(msg);
     const content = (msg.content ?? "").trim().toLowerCase();
-    
-    // 检测是否为紧急命令
+
+    // 2. 检测是否为紧急命令
     const isUrgentCommand = URGENT_COMMANDS.some(cmd => content.startsWith(cmd.toLowerCase()));
-    
+
     if (isUrgentCommand) {
       log?.info(`[qqbot:${account.accountId}] Urgent command detected: ${content.slice(0, 20)}, executing immediately`);
-      
+
       // 清空该用户队列中所有待处理消息
       const queue = userQueues.get(peerId);
       if (queue) {
@@ -519,7 +582,7 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
         totalEnqueued = Math.max(0, totalEnqueued - droppedCount);
         log?.info(`[qqbot:${account.accountId}] Dropped ${droppedCount} queued messages for ${peerId} due to urgent command`);
       }
-      
+
       // 立即异步执行紧急命令，不等待
       if (handleMessageFnRef) {
         handleMessageFnRef(msg).catch(err => {
@@ -528,7 +591,8 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
       }
       return;
     }
-    
+
+    // 3. 正常入队流程
     let queue = userQueues.get(peerId);
     if (!queue) {
       queue = [];


### PR DESCRIPTION
## Problem
Plugins that need user approval (like sudo-control) can cause deadlocks:
- AI sends approval request, awaits response (Promise pending)
- User's reply enters the per-user serial queue
- Queue is blocked waiting for previous message to complete
- Previous message is waiting for user reply → DEADLOCK

## Solution
Add `registerMessagePreprocessor()` API that allows plugins to intercept messages before they enter the queue, enabling a "fast lane" for urgent responses like approval replies.

## Changes
- Export `QueuedMessage` interface for type safety
- Add `MessagePreprocessor` type and `registerMessagePreprocessor()` function
- Call preprocessors at the start of `enqueueMessage()`
- Add comprehensive documentation with usage examples

## Usage
```typescript
const unregister = registerMessagePreprocessor((msg) => {
  if (msg.content.startsWith('批准 sudo-')) {
    resolveApproval(...);
    return true; // handled, don't enqueue
  }
  return false; // continue normal processing
});
```

## Use Cases
- Approval response handling (deadlock prevention)
- Emergency commands (/abort, /stop)
- Quick status queries (/ping, /uptime)
- Message filtering and routing
- 2FA verification codes

## PR Type / PR 类型
<!-- Check the type of this PR / 请在对应类型前打 "x" -->
- [ ] Bug fix / Bug 修复
- [ ] New feature / 新功能
- [ ] Refactoring / 代码重构
- [ ] Documentation / 文档更新
- [ ] Other / 其他: _______________

## What does this PR solve? / 这个 PR 解决了什么问题？
<!-- Briefly describe the purpose. Use "Fixes #123" to link issues -->
<!-- 请简要描述此 PR 的目的。如果解决了某个 Issue，请使用 "Fixes #Issue编号" -->
Fixes #

## How did you test this PR? / 你是如何测试的？
<!-- Describe what tests you ran to verify your changes -->
<!-- 请说明你执行了哪些测试来验证你的更改 -->
- [ ] Ran local tests / 本地运行测试通过
- [ ] Wrote new unit tests / 编写了新的单元测试
- [ ] Covered existing test cases / 覆盖了旧的测试用例

## Test Report / 测试报告
<!-- ⚠️ REQUIRED: Please attach the E2E test report generated by `npm test` -->
<!-- ⚠️ 必须：请上传 `npm test` 生成的 E2E 测试报告 -->
<!--
  Reports are saved in: tests/reports/
  - report-<version>-<date>.json  (JSON report)
  - report-<version>-<date>.txt   (text report)

  报告保存在 tests/reports/ 目录下，请将对应的 JSON 或文本报告粘贴到下方，或作为附件上传。
-->

<details>
<summary>Paste test report here / 在此粘贴测试报告</summary>

```
(paste report content here / 粘贴报告内容)
```

</details>

## Screenshots / 截图 (Optional / 可选)
<!-- If your changes involve UI, provide before/after screenshots -->
<!-- 如果你的更改涉及 UI，请在此处提供前后对比截图 -->


## Checklist / 检查清单
<!-- Check all that apply before submitting / 提交前请确认 -->
- [ ] I have read the contributing guide (CONTRIBUTING.md) / 我已阅读贡献指南
- [ ] Code passes all CI checks / 代码通过了所有 CI 检查
- [ ] I have updated relevant documentation / 我已更新相关文档
- [ ] **I have attached the E2E test report** / **我已上传 E2E 测试报告**

---

## ⚠️ How to Run E2E Tests / 如何运行 E2E 测试

### Step 1: Configure environment / 配置环境变量

```bash
cp tests/.env.example tests/.env
```

Edit `tests/.env` and fill in real values / 编辑 `tests/.env` 填入真实值：

```env
BOT1_APPID=your-bot1-appid
BOT1_SECRET=your-bot1-secret
BOT1_TEST_OPENID=openid-seen-by-bot1

BOT2_APPID=your-bot2-appid
BOT2_SECRET=your-bot2-secret
BOT2_TEST_OPENID=openid-seen-by-bot2
```

### Step 2: Get OpenIDs / 获取 OpenID

> **EN**: Each bot (AppID) generates **unique** OpenIDs for users, groups, and guilds. The same real user will have **different** OpenIDs across different bots. If you need cross-bot identity mapping, a unionid-like mechanism will be provided in the future.
>
> **CN**: 不同的 Bot（AppID）获取到的用户 OpenID、群 OpenID、频道 OpenID **均不相同**。同一个真实用户在不同 Bot 下的 OpenID 是不一样的。若跨业务有关联用户身份需求，后续会提供跨 AppID 绑定后，使用类似 unionid 的机制打通身份。

1. **Start Bot1** / 启动 Bot1
2. **Send a message to Bot1** from your QQ account / 用你的 QQ 号**主动给 Bot1 发一条消息**
3. **Check Bot1's logs** — find the user's OpenID in the incoming message log / 在 Bot1 的**运行日志**中找到你的 OpenID
4. **Fill it into** `BOT1_TEST_OPENID` / 填入 `BOT1_TEST_OPENID`
5. **Repeat for Bot2** — you will get a **different** OpenID / 对 Bot2 重复以上步骤，会得到**不同的** OpenID
6. **Fill it into** `BOT2_TEST_OPENID` / 填入 `BOT2_TEST_OPENID`

> ⚠️ You **must** repeat this for **each bot** — Bot1 and Bot2 will see **different** OpenIDs for the same user.
>
> ⚠️ 每个 Bot 都要分别操作 —— Bot1 和 Bot2 看到的同一用户的 OpenID **是不同的**。

### Step 3: Start Docker / 启动 Docker

```bash
sudo service docker start
```

### Step 4: Run tests / 运行测试

```bash
sudo npm test
```

This will / 该命令会：
- Build a Docker image with OpenClaw + test scripts / 构建包含 OpenClaw 和测试脚本的 Docker 镜像
- Run tests inside the container: plugin install → add channels → restart gateway → send text & file messages / 在容器内运行测试：安装插件 → 添加 channel → 重启 gateway → 发送文本和文件消息
- Save reports to `tests/reports/` / 将报告保存到 `tests/reports/`
- Clean up Docker containers and images after completion / 测试完成后自动清理 Docker 容器和镜像

### Step 5: Check reports / 查看报告

```
tests/reports/report-<version>-<timestamp>.json   # JSON format
tests/reports/report-<version>-<timestamp>.txt    # Text format
```

**Please attach the report in your PR.** / **请在 PR 中上传测试报告。**
