### PR TITLE
feat: auto-seed QQ allowlists on first DM

### DIFF
--- a/src/allowlist-writeback.ts
+++ b/src/allowlist-writeback.ts
@@ -1,0 +1,129 @@
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
+
+import { DEFAULT_ACCOUNT_ID, resolveQQBotAccount } from "./config.js";
+import { getQQBotRuntime } from "./runtime.js";
+import type { ResolvedQQBotAccount } from "./types.js";
+
+type WriteConfigApi = {
+  writeConfigFile: (cfg: OpenClawConfig) => Promise<void>;
+};
+
+type QQBotChannelConfig = {
+  allowFrom?: Array<string | number>;
+  accounts?: Record<string, QQBotAccountEntry | undefined>;
+  [key: string]: unknown;
+};
+
+type QQBotAccountEntry = {
+  allowFrom?: Array<string | number>;
+  [key: string]: unknown;
+};
+
+type CommandsConfig = {
+  ownerAllowFrom?: Array<string | number>;
+  [key: string]: unknown;
+};
+
+function normalizeOpenID(openid: string): string {
+  return openid.trim().toUpperCase();
+}
+
+function hasConfiguredList(value: unknown): boolean {
+  return Array.isArray(value) && value.some((entry) => String(entry ?? "").trim().length > 0);
+}
+
+function cloneQQBotConfig(cfg: OpenClawConfig): QQBotChannelConfig {
+  const existing = (cfg.channels?.qqbot as QQBotChannelConfig | undefined) ?? {};
+  return {
+    ...existing,
+    accounts: existing.accounts ? { ...existing.accounts } : existing.accounts,
+  };
+}
+
+export function buildInitialQQBotAllowlistConfig(params: {
+  cfg: OpenClawConfig;
+  accountId: string;
+  openid: string;
+}): OpenClawConfig | null {
+  const normalizedOpenID = normalizeOpenID(params.openid);
+  if (!normalizedOpenID) {
+    return null;
+  }
+
+  const qqbot = (params.cfg.channels?.qqbot as QQBotChannelConfig | undefined) ?? {};
+  const commands = (params.cfg.commands as CommandsConfig | undefined) ?? {};
+
+  const existingAllowFrom =
+    params.accountId === DEFAULT_ACCOUNT_ID
+      ? qqbot.allowFrom
+      : qqbot.accounts?.[params.accountId]?.allowFrom;
+  const existingOwnerAllowFrom = commands.ownerAllowFrom;
+
+  if (hasConfiguredList(existingAllowFrom) || hasConfiguredList(existingOwnerAllowFrom)) {
+    return null;
+  }
+
+  const nextCfg: OpenClawConfig = structuredClone(params.cfg ?? {});
+  const nextQQBot = cloneQQBotConfig(nextCfg);
+  const ownerEntry = `qqbot:${normalizedOpenID}`;
+
+  if (params.accountId === DEFAULT_ACCOUNT_ID) {
+    nextQQBot.allowFrom = [normalizedOpenID];
+  } else {
+    const accountEntry = {
+      ...(nextQQBot.accounts?.[params.accountId] ?? {}),
+      allowFrom: [normalizedOpenID],
+    };
+    nextQQBot.accounts = {
+      ...(nextQQBot.accounts ?? {}),
+      [params.accountId]: accountEntry,
+    };
+  }
+
+  nextCfg.channels = {
+    ...(nextCfg.channels ?? {}),
+    qqbot: nextQQBot,
+  };
+  nextCfg.commands = {
+    ...((nextCfg.commands as CommandsConfig | undefined) ?? {}),
+    ownerAllowFrom: [ownerEntry],
+  };
+
+  return nextCfg;
+}
+
+export async function maybePersistInitialQQBotAllowlist(params: {
+  cfg: OpenClawConfig;
+  account: ResolvedQQBotAccount;
+  openid: string;
+  log?: { info?: (message: string) => void; warn?: (message: string) => void };
+}): Promise<{ cfg: OpenClawConfig; account: ResolvedQQBotAccount; changed: boolean }> {
+  const nextCfg = buildInitialQQBotAllowlistConfig({
+    cfg: params.cfg,
+    accountId: params.account.accountId,
+    openid: params.openid,
+  });
+  if (!nextCfg) {
+    return {
+      cfg: params.cfg,
+      account: params.account,
+      changed: false,
+    };
+  }
+
+  const runtime = getQQBotRuntime();
+  const configApi = runtime.config as WriteConfigApi;
+  await configApi.writeConfigFile(nextCfg);
+  runtime.setConfig(nextCfg);
+
+  const nextAccount = resolveQQBotAccount(nextCfg, params.account.accountId);
+  params.log?.info?.(
+    `[qqbot:${params.account.accountId}] Seeded initial allowFrom/ownerAllowFrom for ${normalizeOpenID(params.openid)}`,
+  );
+
+  return {
+    cfg: nextCfg,
+    account: nextAccount,
+    changed: true,
+  };
+}

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -1,11 +1,13 @@
 import WebSocket from "ws";
 import path from "node:path";
 import * as fs from "node:fs";
+import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import type { ResolvedQQBotAccount, WSPayload, C2CMessageEvent, GuildMessageEvent, GroupMessageEvent } from "./types.js";
 import { getAccessToken, getGatewayUrl, sendC2CMessage, sendChannelMessage, sendGroupMessage, clearTokenCache, sendC2CImageMessage, sendGroupImageMessage, sendC2CVoiceMessage, sendGroupVoiceMessage, sendC2CVideoMessage, sendGroupVideoMessage, sendC2CFileMessage, sendGroupFileMessage, initApiConfig, startBackgroundTokenRefresh, stopBackgroundTokenRefresh, sendC2CInputNotify, onMessageSent } from "./api.js";
 import { loadSession, saveSession, clearSession, type SessionState } from "./session-store.js";
 import { recordKnownUser, flushKnownUsers } from "./known-users.js";
 import { getQQBotRuntime } from "./runtime.js";
+import { maybePersistInitialQQBotAllowlist } from "./allowlist-writeback.js";
 import { startImageServer, isImageServerRunning, downloadFile, type ImageServerConfig } from "./image-server.js";
 import { getImageSize, formatQQBotMarkdownImage, hasQQBotImageSize, DEFAULT_IMAGE_SIZE } from "./utils/image-size.js";
 import { parseQQBotPayload, encodePayloadForCron, isCronReminderPayload, isMediaPayload, type CronReminderPayload, type MediaPayload } from "./utils/payload.js";
@@ -279,7 +281,7 @@ function filterInternalMarkers(text: string): string {
 export interface GatewayContext {
   account: ResolvedQQBotAccount;
   abortSignal: AbortSignal;
-  cfg: unknown;
+  cfg: OpenClawConfig;
   onReady?: (data: unknown) => void;
   onError?: (error: Error) => void;
   log?: {
@@ -382,6 +384,8 @@ async function ensureImageServer(log?: GatewayContext["log"], publicBaseUrl?: st
  */
 export async function startGateway(ctx: GatewayContext): Promise<void> {
   const { account, abortSignal, cfg, onReady, onError, log } = ctx;
+  let currentCfg = cfg;
+  let currentAccount = account;
 
   if (!account.appId || !account.clientSecret) {
     throw new Error("QQBot not configured (missing appId or clientSecret)");
@@ -700,6 +704,24 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
         refMsgIdx?: string;
         msgIdx?: string;
       }) => {
+        let activeCfg = currentCfg;
+        let activeAccount = currentAccount;
+        if (event.type === "c2c") {
+          const seeded = await maybePersistInitialQQBotAllowlist({
+            cfg: activeCfg,
+            account: activeAccount,
+            openid: event.senderId,
+            log,
+          });
+          if (seeded.changed) {
+            currentCfg = seeded.cfg;
+            currentAccount = seeded.account;
+            activeCfg = seeded.cfg;
+            activeAccount = seeded.account;
+          }
+        }
+        const cfg = activeCfg;
+        const account = activeAccount;
 
         log?.debug?.(`[qqbot:${account.accountId}] Received message: ${JSON.stringify(event)}`);
         log?.info(`[qqbot:${account.accountId}] Processing message from ${event.senderId}: ${event.content}`);

--- a/src/openclaw-plugin-sdk.d.ts
+++ b/src/openclaw-plugin-sdk.d.ts
@@ -21,6 +21,10 @@ declare module "openclaw/plugin-sdk" {
       whatsapp?: unknown;
       [key: string]: unknown;
     };
+    commands?: {
+      ownerAllowFrom?: Array<string | number>;
+      [key: string]: unknown;
+    };
     /** 其他配置字段 */
     [key: string]: unknown;
   }
@@ -94,6 +98,10 @@ declare module "openclaw/plugin-sdk" {
     };
     /** 其他运行时方法 */
     [key: string]: unknown;
+    config?: {
+      writeConfigFile?: (cfg: OpenClawConfig) => Promise<void>;
+      [key: string]: unknown;
+    };
   }
 
   // ============ 插件 API ============


### PR DESCRIPTION
## Summary
- 当用户首次发送私聊消息时，自动将其 openid 写入 allowlist，免去手动配置
- 新增 `allowlist-writeback.ts` 模块处理写入逻辑
- 新增 `openclaw-plugin-sdk.d.ts` 类型声明

## Test plan
- [ ] 验证首次 DM 时 allowlist 被正确写入
- [ ] 验证已在 allowlist 中的用户不会重复写入
- [ ] 验证非 DM 场景不触发写入