### PR TITLE
docs: add TweetClaw QQ workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,31 @@ Scan to join the QQ group chat
 
 > **Note:** This plugin serves as a **message channel** only — it relays messages between QQ and OpenClaw. Capabilities like image understanding, voice transcription, drawing, etc. depend on the **AI model** you configure and the **skills** installed in OpenClaw, not on this plugin itself.
 
+### X/Twitter Workflows With TweetClaw
+
+QQ Bot can be the chat surface while another OpenClaw plugin handles source tools. If your QQ group or private chat needs to scrape tweets, search tweets, search tweet replies, export followers, look up users, monitor tweets, receive webhooks, run giveaway draws, or prepare approval-reviewed post tweets and replies, install [TweetClaw](https://github.com/Xquik-dev/tweetclaw) beside this channel plugin.
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+openclaw plugins inspect tweetclaw --runtime
+```
+
+Keep the Xquik API key in TweetClaw/OpenClaw plugin config, not in QQ Bot config. `tools.alsoAllow` is OpenClaw tool allowlisting: it additively enables `explore` and `tweetclaw` for the QQ chats that should access X/Twitter automation. It does not change QQ Bot command approval. Keep `/bot-approve` in allowlist or strict mode so write-like actions still ask before execution.
+
+```json
+{
+  "tools": {
+    "alsoAllow": ["explore", "tweetclaw"]
+  }
+}
+```
+
+Useful QQ prompts after both plugins are running:
+
+- `@bot use TweetClaw to search tweets about "OpenClaw plugins" and summarize the accounts worth following.`
+- `@bot search tweet replies for this campaign URL and list objections we should answer.`
+- `@bot draft a reply to this tweet. Ask before posting it.`
+
 ### 💬 Quoted Message Context
 
 When a user quotes a message in QQ, the plugin automatically parses the quoted message content and injects it into the AI context, so the model clearly knows "which message the user is replying to" and gives more accurate responses. Supports text and media messages (image/voice/video/file), and works across devices.
@@ -248,7 +273,7 @@ Manage the AI command execution approval policy. Supported subcommands:
 
 ### Step 1 — Create a QQ Bot on the QQ Open Platform
 
-1. Go to the [QQ Open Platform](https://q.qq.com/) and **scan the QR code with your phone QQ** to register / log in. If you haven't registered before, scanning will automatically complete the registration and bind your QQ account.
+1. Go to the [QQ Open Platform](https://q.qq.com/qqbot/openclaw/login.html) and **scan the QR code with your phone QQ** to register / log in. If you haven't registered before, scanning will automatically complete the registration and bind your QQ account.
 
 <img width="3246" height="1886" alt="Clipboard_Screenshot_1772980354" src="https://github.com/user-attachments/assets/d8491859-57e8-47e4-9d39-b21138be54d0" />
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -50,6 +50,31 @@
 
 > **说明：** 本插件仅作为**消息通道**，负责在 QQ 和 OpenClaw 之间传递消息。图片理解、语音转录、AI 画图等能力取决于你配置的 **AI 模型**以及在 OpenClaw 中安装的 **skill**，而非插件本身提供。
 
+### 搭配 TweetClaw 处理 X/Twitter 工作流
+
+QQ Bot 可以作为聊天入口，具体的来源工具交给其他 OpenClaw 插件处理。如果你的 QQ 群聊或私聊需要搜索推文、搜索推文回复、导出粉丝、查询用户、监控推文、接收 webhooks、运行抽奖，或在审批后发布推文和回复，可以把 [TweetClaw](https://github.com/Xquik-dev/tweetclaw) 安装在本通道插件旁边。
+
+```bash
+openclaw plugins install @xquik/tweetclaw
+openclaw plugins inspect tweetclaw --runtime
+```
+
+把 Xquik API key 保存在 TweetClaw/OpenClaw 插件配置中，不要写入 QQ Bot 配置。`tools.alsoAllow` 是 OpenClaw 的工具白名单配置，只会为需要访问 X/Twitter 自动化能力的 QQ 会话额外开放 `explore` 和 `tweetclaw` 工具，不会改变 QQ Bot 的命令审批策略。继续用 `/bot-approve` 保持白名单或严格模式，让写入类动作在执行前仍然请求确认。
+
+```json
+{
+  "tools": {
+    "alsoAllow": ["explore", "tweetclaw"]
+  }
+}
+```
+
+两个插件都运行后，可以在 QQ 中这样使用：
+
+- `@bot 用 TweetClaw 搜索 "OpenClaw plugins" 相关推文，总结值得关注的账号。`
+- `@bot 搜索这个活动链接的推文回复，列出我们需要回应的异议。`
+- `@bot 起草一条回复这条推文的内容，发布前先请求确认。`
+
 ### 💬 引用消息上下文
 
 用户在 QQ 中引用某条消息发送时，插件会自动解析被引用的消息内容并注入 AI 上下文，让模型清楚地知道"用户在回复哪条消息"，从而给出更准确的回复。支持文本及媒体消息（图片/语音/视频/文件），换设备后同样可用。
@@ -243,7 +268,7 @@ AI 可直接发送视频，支持本地文件和公网 URL。
 
 ### 第一步 — 在 QQ 开放平台创建机器人
 
-1. 前往 [QQ 开放平台](https://q.qq.com/)，用**手机 QQ 扫描页面二维码**即可注册/登录。若尚未注册，扫码后系统会自动完成注册并绑定你的 QQ 账号。
+1. 前往 [QQ 开放平台](https://q.qq.com/qqbot/openclaw/login.html)，用**手机 QQ 扫描页面二维码**即可注册/登录。若尚未注册，扫码后系统会自动完成注册并绑定你的 QQ 账号。
 
 <img width="3246" height="1886" alt="Clipboard_Screenshot_1772980354" src="https://github.com/user-attachments/assets/d8491859-57e8-47e4-9d39-b21138be54d0" />
 


### PR DESCRIPTION
## Summary
- add bilingual README guidance for pairing QQ Bot with TweetClaw as a separate OpenClaw plugin
- show safe plugin config boundaries for X/Twitter search, replies, follower export, monitoring, webhooks, giveaway draws, and approval-reviewed posting
- replace the generic q.qq.com setup URL with the direct QQ Bot OpenClaw setup page in both READMEs

## Validation
- git diff --check -- README.md README.zh.md
- npm ci --ignore-scripts --no-audit --no-fund
- npm run build
- npm pack --dry-run --json
- README link sweep for both English and Chinese docs

## Notes
- This keeps TweetClaw optional and out of the QQ Bot config by default. The docs only show how teams can enable it when QQ conversations need X/Twitter automation through OpenClaw.
- npm audit reports existing dependency advisories in the repository baseline; this docs-only change does not add dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a guide for X/Twitter workflows using the TweetClaw plugin, with installation, configuration examples, and sample prompts for QQ bot integration
  * Updated Getting Started to use the dedicated QQ Open Platform OpenClaw login link for a smoother onboarding flow
  * Changes applied to both English and Chinese README files for consistency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tencent-connect/openclaw-qqbot/pull/284?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->