### PR TITLE
Forward verbose tool progress to QQ by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,25 @@ Open QQ, find your bot, and send a message!
 
 ## ⚙️ Advanced Configuration
 
+### Verbose / Tool Progress Forwarding
+
+The plugin forwards OpenClaw `verbose` / tool progress text to QQ by default, so users can see agent actions such as command execution, file reads/writes, and status checks during a run.
+
+If you need to hide these intermediate tool messages, set `forwardToolDeliver` to `false` under `channels.qqbot` or under a specific account config:
+
+```json
+{
+  "channels": {
+    "qqbot": {
+      "enabled": true,
+      "forwardToolDeliver": false
+    }
+  }
+}
+```
+
+When disabled, the plugin still keeps the original fallback behavior for tool-only runs and media forwarding.
+
 ### Multi-Account Setup (Multi-Bot)
 
 Run multiple QQ bots under a single OpenClaw instance.

--- a/README.zh.md
+++ b/README.zh.md
@@ -348,6 +348,25 @@ openclaw gateway restart
 
 ## ⚙️ 进阶配置
 
+### Verbose / Tool 过程转发
+
+插件默认会把 OpenClaw 的 `verbose` / tool 过程文本转发到 QQ，便于在运行中看到 agent 正在执行命令、读取/写入文件、检查状态等操作。
+
+如果需要隐藏这些中间过程消息，可以在 `channels.qqbot` 或具体账号配置下显式设置 `forwardToolDeliver: false`：
+
+```json
+{
+  "channels": {
+    "qqbot": {
+      "enabled": true,
+      "forwardToolDeliver": false
+    }
+  }
+}
+```
+
+关闭后，插件仍保留原有的 tool-only fallback 和媒体转发行为。
+
 ### 多账户配置（Multi-Bot）
 
 支持在同一个 OpenClaw 实例下同时运行多个 QQ 机器人。

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -1424,6 +1424,8 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
           let toolDeliverCount = 0; // tool deliver 计数
           const toolTexts: string[] = []; // 收集所有 tool deliver 文本
           const toolMediaUrls: string[] = []; // 收集所有 tool deliver 媒体 URL
+          const forwardedToolTexts = new Set<string>(); // 已实时转发的 tool 文本，避免 fallback 重复发送
+          const forwardToolDeliver = account.config?.forwardToolDeliver !== false; // 默认转发 verbose/tool 过程文本，可显式设 false 关闭
           let toolFallbackSent = false; // 兜底消息是否已发送（只发一次）
           const blockDeliveredMediaUrls = new Set<string>(); // block deliver 已处理的 mediaUrl，用于 tool 后到时去重
           const responseTimeout = 120000; // 120秒超时（2分钟，与 TTS/文件生成超时对齐）
@@ -1469,10 +1471,15 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
             }
             // 其次转发工具产出的文本
             if (toolTexts.length > 0) {
-              const text = toolTexts.slice(-3).join("\n---\n").slice(0, 2000);
-              log?.info(`[qqbot:${account.accountId}] Tool fallback: forwarding tool text (${text.length} chars)`);
-              await sendErrorMessage(text);
-              return;
+              const fallbackTexts = forwardToolDeliver
+                ? toolTexts.filter((text) => !forwardedToolTexts.has(text))
+                : toolTexts;
+              if (fallbackTexts.length > 0) {
+                const text = fallbackTexts.slice(-3).join("\n---\n").slice(0, 2000);
+                log?.info(`[qqbot:${account.accountId}] Tool fallback: forwarding tool text (${text.length} chars)`);
+                await sendErrorMessage(text);
+                return;
+              }
             }
             // 既无媒体也无文本，静默处理（仅日志记录）
             log?.info(`[qqbot:${account.accountId}] Tool fallback: no media or text collected from ${toolDeliverCount} tool deliver(s), silently dropping`);
@@ -1578,6 +1585,17 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
                       }
                     }
                     return;
+                  }
+
+                  if (forwardToolDeliver && toolText) {
+                    const textToForward = toolText.slice(0, 2000);
+                    try {
+                      forwardedToolTexts.add(toolText);
+                      log?.info(`[qqbot:${account.accountId}] Forwarding tool deliver text (${textToForward.length} chars) because forwardToolDeliver=true`);
+                      await sendErrorMessage(textToForward);
+                    } catch (err) {
+                      log?.error(`[qqbot:${account.accountId}] Failed to forward tool deliver text: ${err}`);
+                    }
                   }
 
                   // 兜底已发送，不再续期

--- a/src/gateway.ts
+++ b/src/gateway.ts
@@ -1590,9 +1590,9 @@ export async function startGateway(ctx: GatewayContext): Promise<void> {
                   if (forwardToolDeliver && toolText) {
                     const textToForward = toolText.slice(0, 2000);
                     try {
-                      forwardedToolTexts.add(toolText);
                       log?.info(`[qqbot:${account.accountId}] Forwarding tool deliver text (${textToForward.length} chars) because forwardToolDeliver=true`);
                       await sendErrorMessage(textToForward);
+                      forwardedToolTexts.add(toolText);
                     } catch (err) {
                       log?.error(`[qqbot:${account.accountId}] Failed to forward tool deliver text: ${err}`);
                     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -149,6 +149,11 @@ export interface QQBotAccountConfig {
    * 注意：仅 C2C（私聊）支持流式消息 API。
    */
   streaming?: boolean;
+  /**
+   * 是否将 OpenClaw verbose/tool 过程文本转发到 QQ（默认 true）。
+   * 执行命令、读写文件等 tool deliver 文本会作为引用回复发送，便于观察 agent 操作过程；设为 false 可关闭。
+   */
+  forwardToolDeliver?: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Forward OpenClaw `verbose` / tool progress text to QQ by default so users can see agent actions during a run.
- Add `channels.qqbot.forwardToolDeliver: false` as an opt-out switch for users who prefer to hide intermediate tool messages.
- Avoid duplicate tool-only fallback text by filtering tool messages that were already forwarded live.
- Document the new behavior in both English and Chinese READMEs.

## Motivation

OpenClaw can emit useful `kind: "tool"` deliver events when verbose progress is enabled, such as command execution, file reads/writes, and status checks. The QQBot plugin previously collected those tool messages and skipped live delivery, only showing them in fallback/tool-only scenarios. That makes `/verbose on` less useful on QQ compared with other surfaces.

This change keeps the existing fallback/media behavior while making tool progress visible by default. Users can opt out with `forwardToolDeliver: false`.

## Validation

- `npm ci`
- `npm run build`
- `./node_modules/.bin/tsc --noEmit --pretty false`

Also validated locally in an OpenClaw gateway install with `@tencent-connect/openclaw-qqbot@1.7.2`: QQ channel stayed OK after restart, `kind: "tool"` deliver text was forwarded to QQ, and QQ API returned `200 OK`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an advanced configuration option to control forwarding of verbose/intermediate tool progress messages to QQ (enabled by default).
  * You can disable this per account while still keeping tool-only fallback behavior and media forwarding.

* **Bug Fixes**
  * Prevents duplicate delivery of intermediate tool progress text during AI execution.

* **Documentation**
  * Updated both English and Chinese README files with the new “Verbose / Tool Progress” settings and example configuration snippet.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->