### PR TITLE
fix: preserve plugin approval button decisions

### DIFF
--- a/src/features/approval-handler.ts
+++ b/src/features/approval-handler.ts
@@ -13,6 +13,7 @@ import type { OpenClawConfig } from "openclaw/plugin-sdk";
 import { getBotForAccount } from "../bot-instance.js";
 import type { PluginLogger } from '../utils/plugin-logger.js';
 import type { InlineKeyboard, KeyboardButton } from "../types.js";
+import { buildApprovalButtonData, type ApprovalDecision } from './approval-utils.js';
 
 import { loadApprovalGatewayRuntime, type ApprovalGatewayClient } from '../adapter/gateway.js';
 type EventFrame = {
@@ -160,9 +161,9 @@ function buildApprovalKeyboard(approvalId: string): InlineKeyboard {
       rows: [
         {
           buttons: [
-            makeBtn("allow",  "✅ 允许一次", "已允许",    `approve:${approvalId}:allow-once`,  1),
-            makeBtn("always", "⭐ 始终允许", "已始终允许", `approve:${approvalId}:allow-always`, 1),
-            makeBtn("deny",   "❌ 拒绝",     "已拒绝",    `approve:${approvalId}:deny`,         0),
+            makeBtn("allow",  "✅ 允许一次", "已允许",    buildApprovalButtonData(approvalId, "allow-once"),  1),
+            makeBtn("always", "⭐ 始终允许", "已始终允许", buildApprovalButtonData(approvalId, "allow-always"), 1),
+            makeBtn("deny",   "❌ 拒绝",     "已拒绝",    buildApprovalButtonData(approvalId, "deny"),         0),
           ],
         },
       ],
@@ -261,7 +262,7 @@ export class QQBotApprovalHandler {
   /** 解析审批请求（供 Interaction 回调或 /approve 命令调用） */
   async resolveApproval(
     approvalId: string,
-    decision: "allow-once" | "allow-always" | "deny"
+    decision: ApprovalDecision
   ): Promise<boolean> {
     if (!this.gatewayClient) {
       this.opts.log?.warn(`[qqbot:${this.opts.accountId}] approval-handler: resolve ignored ${approvalId} → gatewayClient not ready`);

--- a/src/features/approval-utils.ts
+++ b/src/features/approval-utils.ts
@@ -4,6 +4,45 @@
  * 审批 payload 判断逻辑，供 channel.ts 和 features/approval-handler 使用。
  */
 
+export type ApprovalDecision = 'allow-once' | 'allow-always' | 'deny';
+export type ApprovalKind = 'exec' | 'plugin';
+
+export interface ParsedApprovalButtonData {
+  approvalId: string;
+  approvalKind: ApprovalKind;
+  decision: ApprovalDecision;
+}
+
+/** 构造可安全容纳 `plugin:<uuid>` 等带分隔符 ID 的回调数据。 */
+export function buildApprovalButtonData(
+  approvalId: string,
+  decision: ApprovalDecision,
+): string {
+  const approvalKind: ApprovalKind = approvalId.startsWith('plugin:') ? 'plugin' : 'exec';
+  return `approve:v2:${approvalKind}:${encodeURIComponent(approvalId)}:${decision}`;
+}
+
+/** 严格解析审批按钮回调，拒绝未知版本、类型和 decision。 */
+export function parseApprovalButtonData(buttonData: string): ParsedApprovalButtonData | null {
+  const match = buttonData.match(
+    /^approve:v2:(exec|plugin):([^:]+):(allow-once|allow-always|deny)$/,
+  );
+  if (!match) return null;
+
+  const approvalKind = match[1] as ApprovalKind;
+  const decision = match[3] as ApprovalDecision;
+  let approvalId: string;
+  try {
+    approvalId = decodeURIComponent(match[2]!);
+  } catch {
+    return null;
+  }
+  if (!approvalId) return null;
+  if ((approvalId.startsWith('plugin:') ? 'plugin' : 'exec') !== approvalKind) return null;
+
+  return { approvalId, approvalKind, decision };
+}
+
 /** 检查 payload 是否为审批消息（execApproval / plugin approval） */
 export function isApprovalPayload(payload: unknown): boolean {
   if (!payload || typeof payload !== 'object') return false;

--- a/src/gateway/event-handlers.ts
+++ b/src/gateway/event-handlers.ts
@@ -13,6 +13,7 @@ import type { PluginLogger } from '../utils/plugin-logger.js';
 import { dispatchToOpenClaw } from '../dispatch/index.js';
 import { runWithRequestContext } from '../request-context.js';
 import { getApprovalHandler } from '../features/approval-handler.js';
+import { parseApprovalButtonData } from '../features/approval-utils.js';
 import { recordKnownUser } from '../features/proactive.js';
 import { cacheMsgId } from '../features/msgid-cache.js';
 import { getAdapters } from '../adapter/resolve.js';
@@ -156,7 +157,8 @@ async function handleApproval(
   try { await ack(event.id); } catch { /* ignore */ }
 
   const buttonData = event.data?.resolved?.button_data;
-  if (!buttonData?.startsWith('approve:')) return;
+  const approvalAction = parseApprovalButtonData(buttonData ?? '');
+  if (!approvalAction) return;
 
   // 身份授权校验：操作者需在 allowFrom 白名单中
   const operatorId = resolveOperatorId(event);
@@ -165,15 +167,12 @@ async function handleApproval(
     return;
   }
 
-  const parts = buttonData.split(':');
-  if (parts.length < 3) return;
-
   const handler = getApprovalHandler(account.accountId);
   if (!handler) return;
 
-  const approvalId = parts[1];
-  const decision = parts[2] as 'allow-once' | 'allow-always' | 'deny';
-  try { await handler.resolveApproval(approvalId, decision); } catch (err) {
+  try {
+    await handler.resolveApproval(approvalAction.approvalId, approvalAction.decision);
+  } catch (err) {
     log.error(`interaction approve error: ${err instanceof Error ? err.message : String(err)}`);
   }
 }

--- a/tests/approval-button-data.test.ts
+++ b/tests/approval-button-data.test.ts
@@ -1,0 +1,36 @@
+import assert from 'node:assert/strict';
+import {
+  buildApprovalButtonData,
+  parseApprovalButtonData,
+  type ApprovalDecision,
+} from '../src/features/approval-utils.js';
+
+for (const decision of ['allow-once', 'allow-always', 'deny'] satisfies ApprovalDecision[]) {
+  const buttonData = buildApprovalButtonData('plugin:12345678-1234-1234-1234-123456789abc', decision);
+  assert.equal(
+    buttonData,
+    `approve:v2:plugin:plugin%3A12345678-1234-1234-1234-123456789abc:${decision}`,
+  );
+  assert.deepEqual(parseApprovalButtonData(buttonData), {
+    approvalId: 'plugin:12345678-1234-1234-1234-123456789abc',
+    approvalKind: 'plugin',
+    decision,
+  });
+}
+
+assert.deepEqual(parseApprovalButtonData(buildApprovalButtonData('exec:abc123', 'allow-once')), {
+  approvalId: 'exec:abc123',
+  approvalKind: 'exec',
+  decision: 'allow-once',
+});
+
+for (const buttonData of [
+  'approve:plugin:abc123:allow-once',
+  'approve:v2:plugin:plugin%3Aabc123:approved',
+  'approve:v2:exec:plugin%3Aabc123:allow-once',
+  'approve:v2:plugin:%E0%A4%A:allow-once',
+]) {
+  assert.equal(parseApprovalButtonData(buttonData), null);
+}
+
+console.log('approval button data tests passed');


### PR DESCRIPTION
## What Problem This Solves

Plugin approval IDs are generated as `plugin:<uuid>`. The current QQ button payload embeds that ID directly in a colon-delimited string, while the callback handler uses `split(':')` and reads fixed indexes. Clicking Allow therefore resolves `approvalId="plugin"` with the UUID as the decision instead of sending the full plugin approval ID and `allow-once`; the request then expires.

This is the current external-plugin equivalent of openclaw/openclaw#107555.

## Why This Change Was Made

- Encode the complete approval ID in a versioned, kind-tagged callback payload.
- Parse the payload with one strict production helper instead of positional splitting.
- Reject malformed versions, mismatched kinds, invalid percent encoding, and unknown decisions.
- Preserve the existing approval authorization policy.

## User Impact

QQ Allow, Always Allow, and Deny buttons now round-trip complete `plugin:<uuid>` IDs to `plugin.approval.resolve`. Exec approvals continue to use the same three decisions.

## Evidence

- Added a production-helper regression test covering all plugin decisions, exec approval round-trip, and malformed callbacks.
- Compiled and ran the focused regression test: passed.
- `npm run typecheck`: passed.
- `npm run build`: passed.
- Compared the approval sources in npm `@tencent-connect/openclaw-qqbot@2.0.1` with repository `main`; the affected approval files are identical.

Live QQ callback proof is not included because this environment has no QQ Bot application credentials.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more reliable approval button handling for plugin and execution approvals.
  * Approval actions now support validated, structured callback data.

* **Bug Fixes**
  * Improved validation for invalid, outdated, or malformed approval actions.
  * Approval decisions are now consistently passed to the appropriate handler.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->